### PR TITLE
Fix problem with session state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # php-http-lib
 
-This repository is a libary of http clients - Response, Request and Session.
+This repository is a library of http clients - Response, Request and Session.
 
 # Makefile
 
-The libary code provides a Makefile:
+The library code provides a Makefile:
 
 ```
 $ make help
@@ -39,7 +39,7 @@ $ (xDebug) phpbrew ext install xdebug
 
 ## Useful methods in the `Request` Object
 
-- <i>__construct(queryParams, formData, sessionData)</i> - The construct is the field where the query params, form data and session data need to fill in as an array
+- <i>__construct(queryParams, formData, sessionData)</i> - The construct is the field where the query params and form data need to fill in as an array. The third one is a session object.
 - <i>getQueryParams()</i> - Returns query params as an array if available
 - <i>getFormData()</i> - Returns information from the form as an array
 - <i>getSessionData()</i> - Returns session data as an array
@@ -52,9 +52,9 @@ $ (xDebug) phpbrew ext install xdebug
 
 ## `Session` Object
 
-The Session Object handles with magic proberties and methods.
+The Session Object handles with magic properties and methods.
 
-- Set proberties via __construct or define proberties with the session object
+- Set properties via __construct or define properties with the session object
 
 ```
 (example)
@@ -62,7 +62,7 @@ The Session Object handles with magic proberties and methods.
 2. $session->foo = "bar";
 ```
 
-- Get proberties
+- Get properties
 
 ```
 (example)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jimdo/http",
-    "description": "Libary of Http Clients",
+    "description": "Library of Http Clients",
     "license": "MIT",
     "authors": [
         {

--- a/src/Session.php
+++ b/src/Session.php
@@ -10,15 +10,9 @@ class Session
     /**
      * @param array $sessionData
      */
-    public function __construct(array $sessionData)
+    public function __construct(array &$sessionData)
     {
-        if ($sessionData !== []) {
-            foreach ($sessionData as $key => $value) {
-
-            // $key defines the proberty and $value fill the proberty
-            $this->__set($key, $value);
-            }
-        }
+        $this->data = &$sessionData;
     }
 
     /**
@@ -32,11 +26,10 @@ class Session
 
     /**
      * @param mixed $name
-     * @return mixed
      */
     public function __get($name)
     {
-        if (array_key_exists($name, $this->data)) {
+        if (isset($this->data[$name])) {
             return $this->data[$name];
         }
         return null;

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -37,4 +37,20 @@ class SessionTest extends TestCase
         $value = $session->name;
         $this->assertTrue(isset($value));
     }
+
+    /**
+     * @test
+     */
+    public function itShouldModifyGivenSessionData()
+    {
+        $sessionData = [
+            'hase' => 'nicht knuddelig',
+        ];
+
+        $session = new Session($sessionData);
+
+        $session->hase = 'sehr knuddelig';
+
+        $this->assertEquals($sessionData['hase'], 'sehr knuddelig');
+    }
 }


### PR DESCRIPTION
Right now the `Session` object only maintains the "internal state" of it's `data` variable. Have a look at **how PHP handles references in parameter handling** and fix it accordingly. 😸 